### PR TITLE
Fixes issues which would arise on non-SP worlds

### DIFF
--- a/src/main/java/com/zygzag/revamp/common/Revamp.java
+++ b/src/main/java/com/zygzag/revamp/common/Revamp.java
@@ -40,6 +40,7 @@ import net.minecraft.world.level.block.state.properties.WoodType;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.levelgen.SurfaceRules;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.client.event.RegisterGuiOverlaysEvent;
@@ -107,7 +108,6 @@ public class Revamp {
         modEventBus.addListener(this::registerAttributes);
         modEventBus.addListener(this::registerCapabilities);
         modEventBus.addListener(this::registerRenderers);
-        modEventBus.addListener(this::registerBlockColorHandlers);
         Registry.register(modEventBus);
 
         // forgeEventBus.addListener(this::doServerStuff);
@@ -364,8 +364,14 @@ public class Revamp {
         event.registerBlockEntityRenderer(BlockEntityTypeRegistry.CUSTOM_SIGN.get(), SignRenderer::new);
     }
 
-    private void registerBlockColorHandlers(final RegisterColorHandlersEvent.Block event) {
-        event.register(ArcCrystalBlock::getColor, BlockRegistry.ARC_CRYSTAL.get());
+    
+    @Mod.EventBusSubscriber(value = Dist.CLIENT)
+    public static class ClientEvents {
+    	
+    	@SubscribeEvent
+	    public static void registerBlockColorHandlers(final RegisterColorHandlersEvent.Block event) {
+	        event.register(ArcCrystalBlock::getColor, BlockRegistry.ARC_CRYSTAL.get());
+	    }
     }
 
     // private void doServerStuff(final FMLServerStartingEvent event) { }

--- a/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundArcCreationPacket.java
+++ b/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundArcCreationPacket.java
@@ -5,6 +5,9 @@ import com.zygzag.revamp.util.ClientUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.function.Supplier;
@@ -37,6 +40,8 @@ public class ClientboundArcCreationPacket {
     }
 
     public void handle(Supplier<NetworkEvent.Context> ctxSupp) {
-        ClientUtils.createArc(ctxSupp, arc);
+    	NetworkEvent.Context ctx = ctxSupp.get();
+    	ClientUtils.createArc(arc);
+    	ctx.setPacketHandled(true);
     }
 }

--- a/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundArcCreationPacket.java
+++ b/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundArcCreationPacket.java
@@ -2,12 +2,8 @@ package com.zygzag.revamp.common.networking.packet;
 
 import com.zygzag.revamp.common.charge.Arc;
 import com.zygzag.revamp.util.ClientUtils;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.function.Supplier;

--- a/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundChargeUpdatePacket.java
+++ b/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundChargeUpdatePacket.java
@@ -5,9 +5,6 @@ import com.zygzag.revamp.util.ClientUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.List;

--- a/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundChargeUpdatePacket.java
+++ b/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundChargeUpdatePacket.java
@@ -2,17 +2,18 @@ package com.zygzag.revamp.common.networking.packet;
 
 import com.zygzag.revamp.common.charge.EnergyCharge;
 import com.zygzag.revamp.util.ClientUtils;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+
 
 public class ClientboundChargeUpdatePacket {
     private final Map<BlockPos, EnergyCharge> toSync;
@@ -40,16 +41,12 @@ public class ClientboundChargeUpdatePacket {
     }
 
     public static ClientboundChargeUpdatePacket decode(FriendlyByteBuf buf) {
-        return ClientUtils.decodeClientboundChargeUpdatePacket(buf);
+    	return ClientUtils.decodeClientboundChargeUpdatePacket(buf);
     }
 
     public void handle(Supplier<NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context ctx = contextSupplier.get();
-        ctx.enqueueWork(() ->
-            DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-                ClientUtils.chargeUpdate(toSync, toRemove);
-            })
-        );
+        ClientUtils.chargeUpdate(toSync, toRemove);
         ctx.setPacketHandled(true);
     }
 }

--- a/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundEntityChargeSyncPacket.java
+++ b/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundEntityChargeSyncPacket.java
@@ -1,16 +1,7 @@
 package com.zygzag.revamp.common.networking.packet;
 
-import com.zygzag.revamp.common.Revamp;
 import com.zygzag.revamp.util.ClientUtils;
-import com.zygzag.revamp.util.GeneralUtil;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.Level;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.loading.FMLEnvironment;
-import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 
 import javax.annotation.Nullable;

--- a/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundEntityChargeSyncPacket.java
+++ b/src/main/java/com/zygzag/revamp/common/networking/packet/ClientboundEntityChargeSyncPacket.java
@@ -7,6 +7,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkEvent;
 
 import javax.annotation.Nullable;
@@ -32,10 +36,12 @@ public class ClientboundEntityChargeSyncPacket {
 
     @Nullable
     public static ClientboundEntityChargeSyncPacket decode(FriendlyByteBuf buf) {
-        return ClientUtils.decodeClientboudnEntityChargeSyncPacket(buf);
+    	return ClientUtils.decodeClientboudnEntityChargeSyncPacket(buf);
     }
 
     public void handle(Supplier<NetworkEvent.Context> ctxSupplier) {
-        ClientUtils.syncEntityCharge(ctxSupplier, uuid, newCharge, newMaxCharge);
+    	NetworkEvent.Context ctx = ctxSupplier.get();
+    	ClientUtils.syncEntityCharge(uuid, newCharge, newMaxCharge);
+    	ctx.setPacketHandled(true);
     }
 }


### PR DESCRIPTION
Based on info provided by XFactHD on the forge discord, this implements needed fixes after removing the previous checks for the MC instance in the packets to ensure there are no issues when in a multiplayer context.

All this does is check the dist to static initialize an optional that holds the MC instance. If for whatever reason the `ClientUtils` class is initialized in the server, the methods within will use the newly added `Optional` to poll the MC instance, and use that optional to dictate whether inner logic of the functions should run, or if it should prematurely terminate.

It also now marks the packets as handled in the packet class themselves rather than needing to pass it into the methods of `ClientUtils`